### PR TITLE
Turn DatagramPackets into FileBuilder

### DIFF
--- a/src/packet/BodyPacket.java
+++ b/src/packet/BodyPacket.java
@@ -10,6 +10,12 @@ public class BodyPacket extends Packet {
         this.packetNumber = packetNumber;
     }
 
+    protected BodyPacket(Byte fileId, int packetNumber, boolean isFinal) {
+        super(fileId);
+        this.packetNumber = packetNumber;
+        this.isFinal = isFinal;
+    }
+
     public int getPacketNumber(){
         return packetNumber;
     }

--- a/src/packet/BodyPacket.java
+++ b/src/packet/BodyPacket.java
@@ -1,10 +1,9 @@
 package packet;
 
-class BodyPacket extends Packet {
+public class BodyPacket extends Packet {
     
     protected int packetNumber;
     protected boolean isFinal;
-    Byte[] bodyData; //Could possibly be in superclass, and HeaderPacket just calculates it as a string?
 
     protected BodyPacket(Byte fileId, int packetNumber) {
         super(fileId);

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -1,6 +1,8 @@
 package packet;
 
+import java.util.Arrays;
 import java.util.PriorityQueue;
+import java.util.stream.Stream;
 
 public class FileBuilder {
     protected PriorityQueue<BodyPacket> fileData = new PriorityQueue<BodyPacket>((BodyPacket x, BodyPacket y) ->  {return x.getPacketNumber() - y.getPacketNumber(); });
@@ -36,9 +38,13 @@ public class FileBuilder {
         return true;
     }
 
-    public byte[][] getFileBody(){
+    public byte[][] getFileBody() {
 
-        return null;
+        return fileData.stream()
+            .map((BodyPacket x) -> x.getBodyData())
+            .toArray(byte[][]::new);
+
+
     }
 
     public boolean isComplete(){

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -1,5 +1,6 @@
 package packet;
 
+import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 import java.util.PriorityQueue;
 import java.util.stream.Stream;
@@ -8,6 +9,7 @@ public class FileBuilder {
     protected PriorityQueue<BodyPacket> fileData = new PriorityQueue<BodyPacket>((BodyPacket x, BodyPacket y) ->  {return x.getPacketNumber() - y.getPacketNumber(); });
     protected String fileName;
     int numPackets = 0;
+    private boolean finishedWriting = false;
 
     public FileBuilder() {
 
@@ -20,7 +22,8 @@ public class FileBuilder {
             addBody((BodyPacket) p);
         }
 
-        return true;
+        return this.isComplete();
+        // Returns true if the builder is ready to write to a file.
     }
 
     protected boolean addHeader(HeaderPacket p){
@@ -44,7 +47,16 @@ public class FileBuilder {
             .map((BodyPacket x) -> x.getBodyData())
             .toArray(byte[][]::new);
 
+    }
 
+    public ByteArrayOutputStream getFileBodyStream() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        fileData.stream()
+            .map((BodyPacket x) -> x.getBodyData())
+            .forEach((byte[] b) -> output.write(b, 0, b.length));
+        
+        return output;
     }
 
     public boolean isComplete(){
@@ -53,8 +65,17 @@ public class FileBuilder {
             && fileData.size() == numPackets;
     }
 
+    public boolean isFinishedWriting(){
+        return finishedWriting;
+    }
+
     public String getFileName(){
         return fileName;
+    }
+
+    public void writeToFile() {
+
+        finishedWriting = true;
     }
 
 }

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -48,8 +48,9 @@ public class FileBuilder {
     }
 
     public boolean isComplete(){
-
-        return false;
+        return fileName != null
+            && numPackets != 0
+            && fileData.size() == numPackets;
     }
 
     public String getFileName(){

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -12,12 +12,18 @@ public class FileBuilder {
     }
 
     public boolean addPacket(Packet p){
+        if (p instanceof HeaderPacket) {
+            addHeader((HeaderPacket) p);
+        } else if (p instanceof BodyPacket){
+            addBody((BodyPacket) p);
+        }
 
         return true;
     }
 
     protected boolean addHeader(HeaderPacket p){
 
+        fileName = p.getFileName();
         return true;
     }
 

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -36,7 +36,7 @@ public class FileBuilder {
         return true;
     }
 
-    public byte[] getFileBody(){
+    public byte[][] getFileBody(){
 
         return null;
     }

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -5,7 +5,7 @@ import java.util.PriorityQueue;
 public class FileBuilder {
     protected PriorityQueue<BodyPacket> fileData = new PriorityQueue<BodyPacket>((BodyPacket x, BodyPacket y) ->  {return x.getPacketNumber() - y.getPacketNumber(); });
     protected String fileName;
-    int numBytes = 0;
+    int numPackets = 0;
 
     public FileBuilder() {
 
@@ -28,6 +28,10 @@ public class FileBuilder {
     }
 
     protected boolean addBody(BodyPacket p){
+        if(p.isFinal()){
+            numPackets = p.getPacketNumber() + 1;
+        }
+        fileData.add(p);
 
         return true;
     }

--- a/src/packet/FileBuilder.java
+++ b/src/packet/FileBuilder.java
@@ -1,0 +1,43 @@
+package packet;
+
+import java.util.PriorityQueue;
+
+public class FileBuilder {
+    protected PriorityQueue<BodyPacket> fileData = new PriorityQueue<BodyPacket>((BodyPacket x, BodyPacket y) ->  {return x.getPacketNumber() - y.getPacketNumber(); });
+    protected String fileName;
+    int numBytes = 0;
+
+    public FileBuilder() {
+
+    }
+
+    public boolean addPacket(Packet p){
+
+        return true;
+    }
+
+    protected boolean addHeader(HeaderPacket p){
+
+        return true;
+    }
+
+    protected boolean addBody(BodyPacket p){
+
+        return true;
+    }
+
+    public byte[] getFileBody(){
+
+        return null;
+    }
+
+    public boolean isComplete(){
+
+        return false;
+    }
+
+    public String getFileName(){
+        return fileName;
+    }
+
+}

--- a/src/packet/HeaderPacket.java
+++ b/src/packet/HeaderPacket.java
@@ -1,6 +1,6 @@
 package packet;
 
-class HeaderPacket extends Packet {
+public class HeaderPacket extends Packet {
 
     private String fileName;
 
@@ -11,5 +11,9 @@ class HeaderPacket extends Packet {
     protected HeaderPacket (Byte fileId, String fileName) {
         super(fileId);
         this.fileName = fileName;
+    }
+
+    public String getFileName() {
+        return fileName;
     }
 }

--- a/src/packet/Packet.java
+++ b/src/packet/Packet.java
@@ -2,18 +2,18 @@ package packet;
 
 public abstract class Packet {
     
-    private Byte fileId;
-    protected Byte[] bodyData;
+    private byte fileId;
+    protected byte[] bodyData;
 
-    public Byte getFileId() {
+    public byte getFileId() {
         return fileId;
     }
 
-    public Byte[] getBodyData() {
+    public byte[] getBodyData() {
         return bodyData;
     }
 
-    protected Packet(Byte fileId) {
+    protected Packet(byte fileId) {
         this.fileId = fileId;
     }
 

--- a/src/packet/Packet.java
+++ b/src/packet/Packet.java
@@ -3,9 +3,14 @@ package packet;
 public abstract class Packet {
     
     private Byte fileId;
+    protected Byte[] bodyData;
 
     public Byte getFileId() {
         return fileId;
+    }
+
+    public Byte[] getBodyData() {
+        return bodyData;
     }
 
     protected Packet(Byte fileId) {

--- a/src/packet/PacketFactory.java
+++ b/src/packet/PacketFactory.java
@@ -1,6 +1,7 @@
 package packet;
 
 import java.net.DatagramPacket;
+import java.util.Arrays;
 
 public class PacketFactory {
 
@@ -12,8 +13,15 @@ public class PacketFactory {
         byte statusByte = inputData[0];
         byte fileId = inputData[1];
 
-        output = null; //obviously just a placeholder
-
+        if (statusByte % 2 == 0) {
+            String fileName = new String(inputData, 2, inputLength - 2);
+            output = new HeaderPacket(fileId, fileName);
+            output.bodyData = Arrays.copyOfRange(inputData, 2, inputLength);
+        } else {
+            int packetNumber = (256 * Byte.toUnsignedInt(inputData[2])) + Byte.toUnsignedInt(inputData[3]);
+            output = new BodyPacket(fileId, packetNumber, (statusByte % 4 == 3));
+            output.bodyData = Arrays.copyOfRange(inputData, 4, inputLength);
+        }
 
         return output;
     }

--- a/src/packet/PacketFactory.java
+++ b/src/packet/PacketFactory.java
@@ -4,10 +4,16 @@ import java.net.DatagramPacket;
 
 public class PacketFactory {
 
-    public Packet parsePacket(DatagramPacket inputPacket) {
+    public static Packet parsePacket(DatagramPacket inputPacket) {
         Packet output;
+        byte[] inputData = inputPacket.getData();
+        int inputLength = inputPacket.getLength();
+
+        byte statusByte = inputData[0];
+        byte fileId = inputData[1];
 
         output = null; //obviously just a placeholder
+
 
         return output;
     }

--- a/src/segmentedfilesystem/FileManager.java
+++ b/src/segmentedfilesystem/FileManager.java
@@ -29,10 +29,11 @@ public class FileManager {
     public boolean addPacket (Packet toAdd){
 
         Byte targetFile = toAdd.getFileId();
-        if(files.putIfAbsent(targetFile, new FileBuilder()).addPacket(toAdd)) {
+        FileBuilder targetedBuilder = files.putIfAbsent(targetFile, new FileBuilder());
+        if(targetedBuilder.addPacket(toAdd)) {
             // putIfAbsent returns the value corresponding to the key provided,
             // and addPacket returns true if the fileBuilder is now done
-            FileBuilderRunnable builderRunnable = new FileBuilderRunnable(files.get(targetFile));
+            FileBuilderRunnable builderRunnable = new FileBuilderRunnable(targetedBuilder);
             Thread writingThread = new Thread(builderRunnable);
             writingThread.start();
         }
@@ -46,6 +47,10 @@ public class FileManager {
     }
 
     public boolean isComplete() {
+
+        if(files.size() != NUM_FILES_EXPECTED) {
+            return false;
+        }
 
         for(FileBuilder b: files.values()) {
             if(!(b.isComplete())) {

--- a/src/segmentedfilesystem/FileManager.java
+++ b/src/segmentedfilesystem/FileManager.java
@@ -1,6 +1,8 @@
 package segmentedfilesystem;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import packet.FileBuilder;
@@ -38,6 +40,24 @@ public class FileManager {
         
         
         return false; // Placeholder
+    }
+
+    public class fileBuilderThread implements Runnable {
+        FileBuilder buildFrom;
+
+        public fileBuilderThread(FileBuilder builder) {
+            this.buildFrom = builder;
+        }
+
+        @Override
+        public void run() {
+            try {
+                FileOutputStream outputStream = new FileOutputStream(buildFrom.getFileName(), true);
+                buildFrom.getFileBodyStream().writeTo(outputStream);
+            } catch (IOException e) {
+                System.err.println(e);
+            }
+        }
     }
 
 

--- a/src/segmentedfilesystem/FileManager.java
+++ b/src/segmentedfilesystem/FileManager.java
@@ -1,0 +1,44 @@
+package segmentedfilesystem;
+
+import java.io.File;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import packet.FileBuilder;
+import packet.Packet;
+
+public class FileManager {
+    public final int NUM_FILES_EXPECTED;
+    private ConcurrentSkipListMap<Byte, FileBuilder> files;
+    // ConcurrentSkipListMaps are able to add elements atomically.  This is useful,
+    // because file input is frequently streamed in and it could be useful to be able
+    // to process packets concurrently.  The map is sorted, which isn't actually
+    // a feature we don't particularly care about or even want, but since it isn't
+    // actively detrimental, using this data structure is still a good idea for the
+    // aforementioned reasons.
+
+    public FileManager(int filesExpected){
+        NUM_FILES_EXPECTED = filesExpected;
+    }
+
+    public FileManager() {
+        NUM_FILES_EXPECTED = 3; //per problem specification
+    }
+
+    public boolean addPacket (Packet toAdd){
+        
+
+        return true; 
+        // adding to some structures returns true, but other times,
+        // such as when adding to a map, it returns the element added.
+        // Currently this function uses the first convention, but it
+        // could be switched to the second without causing any problems.
+    }
+
+    public boolean isComplete() {
+        
+        
+        return false; // Placeholder
+    }
+
+
+}

--- a/src/segmentedfilesystem/FileManager.java
+++ b/src/segmentedfilesystem/FileManager.java
@@ -27,6 +27,15 @@ public class FileManager {
     }
 
     public boolean addPacket (Packet toAdd){
+
+        Byte targetFile = toAdd.getFileId();
+        if(files.putIfAbsent(targetFile, new FileBuilder()).addPacket(toAdd)) {
+            // putIfAbsent returns the value corresponding to the key provided,
+            // and addPacket returns true if the fileBuilder is now done
+            FileBuilderRunnable builderRunnable = new FileBuilderRunnable(files.get(targetFile));
+            Thread writingThread = new Thread(builderRunnable);
+            writingThread.start();
+        }
         
 
         return true; 
@@ -42,10 +51,10 @@ public class FileManager {
         return false; // Placeholder
     }
 
-    public class fileBuilderThread implements Runnable {
+    public class FileBuilderRunnable implements Runnable {
         FileBuilder buildFrom;
 
-        public fileBuilderThread(FileBuilder builder) {
+        public FileBuilderRunnable(FileBuilder builder) {
             this.buildFrom = builder;
         }
 

--- a/src/segmentedfilesystem/FileManager.java
+++ b/src/segmentedfilesystem/FileManager.java
@@ -46,9 +46,13 @@ public class FileManager {
     }
 
     public boolean isComplete() {
-        
-        
-        return false; // Placeholder
+
+        for(FileBuilder b: files.values()) {
+            if(!(b.isComplete())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public class FileBuilderRunnable implements Runnable {

--- a/test/packet/FileBuilderTest.java
+++ b/test/packet/FileBuilderTest.java
@@ -152,7 +152,9 @@ public class FileBuilderTest {
         byte[] fileData = new byte[1024];
         BodyPacket[] toAdd = new BodyPacket[5];
         byte[][] allAdded = new byte[5][1024];
+        //byte[] allAdded = new byte[1024*5];
 
+        int position = 0;
         for(int i = 0; i < 5; i++){
             r.nextBytes(fileData);
         
@@ -160,14 +162,24 @@ public class FileBuilderTest {
             body.bodyData = fileData;
             
             toAdd[i] = body;
+            //allAdded[i] = fileData;
+            //System.arraycopy(fileData, 0, allAdded, position, 1024);
+            //position += 1024;
             allAdded[i] = fileData;
             testBuilder.addBody(body);
         }
 
+        byte[][] outputData = testBuilder.getFileBody();
+        assertEquals(5, outputData.length);
+        for(int i = 0; i < outputData.length; i++) {
+            assertArrayEquals(allAdded[i], outputData[i]);
+        }
+        /*
         byte[][] fileBody = testBuilder.getFileBody();
         for (int i = 0; i < 5; i++){
             assertArrayEquals(allAdded[i], fileBody[i]);
         }
+        */
 
     }
 }

--- a/test/packet/FileBuilderTest.java
+++ b/test/packet/FileBuilderTest.java
@@ -1,0 +1,143 @@
+package packet;
+
+import static org.junit.Assert.*;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+
+public class FileBuilderTest {
+    
+    @Test
+    public void fileBuilderCreated() {
+        FileBuilder testBuilder = new FileBuilder();
+
+        assertNotNull(testBuilder);
+    }
+
+    @Test
+    public void addHeaderPacketDirectly() {
+        FileBuilder testBuilder = new FileBuilder();
+
+        HeaderPacket header = new HeaderPacket(new Integer(0).byteValue(), "testName");
+        testBuilder.addHeader(header);
+
+        assertEquals("testName", testBuilder.getFileName());
+    }
+
+    @Test
+    public void addBodyPacketDirectly() {
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+        r.nextBytes(fileData);
+        
+        BodyPacket body = new BodyPacket(new Integer(0).byteValue(), 0, false);
+        body.bodyData = fileData;
+
+        testBuilder.addBody(body);
+
+        assertTrue(testBuilder.fileData.contains(body));
+    }
+
+    @Test
+    public void addMultipleBodyPacketsDirectly(){
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+        BodyPacket[] toAdd = new BodyPacket[5];
+
+        for(int i = 0; i < 5; i++){
+            r.nextBytes(fileData);
+        
+            BodyPacket body = new BodyPacket(new Integer(0).byteValue(), i, false);
+            body.bodyData = fileData;
+            
+            toAdd[i] = body;
+            testBuilder.addBody(body);
+        }
+
+        assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+    }
+
+    @Test
+    public void addHeaderPacket(){
+        FileBuilder testBuilder = new FileBuilder();
+
+        HeaderPacket header = new HeaderPacket(new Integer(0).byteValue(), "testName");
+        testBuilder.addPacket(header);
+
+        assertEquals("testName", testBuilder.getFileName());
+    }
+
+    @Test
+    public void addBodyPacket(){
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+        r.nextBytes(fileData);
+        
+        BodyPacket body = new BodyPacket(new Integer(0).byteValue(), 0, false);
+        body.bodyData = fileData;
+
+        testBuilder.addPacket(body);
+
+        assertTrue(testBuilder.fileData.contains(body));
+    }
+
+    @Test
+    public void addMultipleBodyPackets(){
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+        BodyPacket[] toAdd = new BodyPacket[5];
+
+        for(int i = 0; i < 5; i++){
+            r.nextBytes(fileData);
+        
+            BodyPacket body = new BodyPacket(new Integer(0).byteValue(), i, false);
+            body.bodyData = fileData;
+            
+            toAdd[i] = body;
+            testBuilder.addPacket(body);
+        }
+
+        assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+    }
+
+    @Test
+    public void addMixedPackets(){
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+        BodyPacket[] toAdd = new BodyPacket[5];
+
+        for(int i = 0; i < 5; i++){
+            r.nextBytes(fileData);
+        
+            BodyPacket body = new BodyPacket(new Integer(0).byteValue(), i, false);
+            body.bodyData = fileData;
+            
+            toAdd[i] = body;
+            testBuilder.addBody(body);
+        }
+
+        HeaderPacket header = new HeaderPacket(new Integer(0).byteValue(), "testName");
+        testBuilder.addPacket(header);
+
+        assertEquals("testName", testBuilder.getFileName());
+        assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+    }
+
+    @Test
+    public void returnFullBodyData(){
+        fail(); // Currently have no clue how to write the code for testing, because it is in some ways similar
+                // to the code for actually doing the task.
+    }
+}

--- a/test/packet/FileBuilderTest.java
+++ b/test/packet/FileBuilderTest.java
@@ -60,7 +60,10 @@ public class FileBuilderTest {
             testBuilder.addBody(body);
         }
 
-        assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+        //assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+        for(int i = 0; i < 5; i++){
+            assertEquals(toAdd[i], (BodyPacket)testBuilder.fileData.toArray()[i]);
+        }
     }
 
     @Test
@@ -107,7 +110,10 @@ public class FileBuilderTest {
             testBuilder.addPacket(body);
         }
 
-        assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+        //assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+        for(int i = 0; i < 5; i++){
+            assertEquals(toAdd[i], (BodyPacket)testBuilder.fileData.toArray()[i]);
+        }
     }
 
     @Test
@@ -132,7 +138,10 @@ public class FileBuilderTest {
         testBuilder.addPacket(header);
 
         assertEquals("testName", testBuilder.getFileName());
-        assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+        //assertArrayEquals(toAdd, (BodyPacket[])testBuilder.fileData.toArray());
+        for(int i = 0; i < 5; i++){
+            assertEquals(toAdd[i], (BodyPacket)testBuilder.fileData.toArray()[i]);
+        }
     }
 
     @Test

--- a/test/packet/FileBuilderTest.java
+++ b/test/packet/FileBuilderTest.java
@@ -182,4 +182,26 @@ public class FileBuilderTest {
         */
 
     }
+
+    @Test
+    public void determineCompleteness(){
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+
+        assertFalse(testBuilder.isComplete());
+
+        HeaderPacket header = new HeaderPacket(new Integer(0).byteValue(), "testName");
+        testBuilder.addPacket(header);
+
+        for(int i = 0; i < 5; i++) {
+            assertFalse(testBuilder.isComplete());
+
+            r.nextBytes(fileData);
+            BodyPacket body = new BodyPacket(new Integer(0).byteValue(), i, i == 4);
+            testBuilder.addPacket(body);
+        }
+        assertTrue(testBuilder.isComplete());
+    }
 }

--- a/test/packet/FileBuilderTest.java
+++ b/test/packet/FileBuilderTest.java
@@ -146,7 +146,28 @@ public class FileBuilderTest {
 
     @Test
     public void returnFullBodyData(){
-        fail(); // Currently have no clue how to write the code for testing, because it is in some ways similar
-                // to the code for actually doing the task.
+        FileBuilder testBuilder = new FileBuilder();
+        Random r = new Random();
+
+        byte[] fileData = new byte[1024];
+        BodyPacket[] toAdd = new BodyPacket[5];
+        byte[][] allAdded = new byte[5][1024];
+
+        for(int i = 0; i < 5; i++){
+            r.nextBytes(fileData);
+        
+            BodyPacket body = new BodyPacket(new Integer(0).byteValue(), i, i == 4);
+            body.bodyData = fileData;
+            
+            toAdd[i] = body;
+            allAdded[i] = fileData;
+            testBuilder.addBody(body);
+        }
+
+        byte[][] fileBody = testBuilder.getFileBody();
+        for (int i = 0; i < 5; i++){
+            assertArrayEquals(allAdded[i], fileBody[i]);
+        }
+
     }
 }

--- a/test/packet/PacketCreationTest.java
+++ b/test/packet/PacketCreationTest.java
@@ -1,0 +1,183 @@
+package packet;
+
+import static org.junit.Assert.*;
+
+import java.net.DatagramPacket;
+import java.util.Random;
+
+import org.junit.Test;
+
+import packet.*;
+
+import java.lang.System.*;
+
+public class PacketCreationTest {
+    
+    @Test
+    public void packetCreated() {
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        Random r = new Random();
+        
+        r.nextBytes(inputPacket);
+
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(1028);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertNotNull(createdPacket);
+    }
+
+    @Test
+    public void headerPacketCreated() {
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        Random r = new Random();
+
+        r.nextBytes(inputPacket);
+
+        inputPacket[0] = new Integer(2).byteValue();
+        
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(1028);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertNotNull(createdPacket);
+    }
+
+    @Test
+    public void bodyPacketCreated() {
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        Random r = new Random();
+
+        r.nextBytes(inputPacket);
+
+        inputPacket[0] = new Integer(1).byteValue();
+        inputPacket[1] = new Integer(1).byteValue();
+
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(1028);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertNotNull(createdPacket);
+        assertTrue("The created packet should be a body packet", createdPacket instanceof BodyPacket);
+        assertFalse("The created packet should not be the last packet", ((BodyPacket)createdPacket).isFinal());
+        assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
+
+    }
+
+    @Test
+    public void finalBodyPacketCreated() {
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        Random r = new Random();
+
+        r.nextBytes(inputPacket);
+
+        inputPacket[0] = new Integer(3).byteValue();
+        inputPacket[1] = new Integer(1).byteValue();
+        
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(1028);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertNotNull(createdPacket);
+        assertTrue("The created packet should be a body packet", createdPacket instanceof BodyPacket);
+        assertTrue("The created packet should be the last packet", ((BodyPacket)createdPacket).isFinal());
+        assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
+
+    }
+
+    @Test
+    public void headerPacketContainsCorrectNameSingleByte() {
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        inputPacket[0] = new Integer(2).byteValue();
+        inputPacket[1] = new Integer(1).byteValue();
+        inputPacket[2] = new String("a").getBytes()[0];
+
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(3);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertNotNull(createdPacket);
+        assertTrue("The created packet should be a header packet", createdPacket instanceof HeaderPacket);
+        assertEquals("a", ((HeaderPacket) createdPacket).getFileName());
+        assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
+    }
+
+    @Test
+    public void headerPacketContainsCorrectNameMultiByte() {
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        byte[] packetName = new String("reallyRatherExcessivelyLongFileName").getBytes();
+        inputPacket[0] = new Integer(2).byteValue();
+        inputPacket[1] = new Integer(1).byteValue();
+        System.arraycopy(packetName, 0, inputPacket, 2, packetName.length);
+
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(packetName.length + 2);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertNotNull(createdPacket);
+        assertTrue("The created packet should be a header packet", createdPacket instanceof HeaderPacket);
+        assertEquals("reallyRatherExcessivelyLongFileName", ((HeaderPacket) createdPacket).getFileName());
+        assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
+    }
+
+    @Test
+    public void bodyPacketContainsCorrectBody(){
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        Random r = new Random();
+
+        byte[] bodyValue = new byte[1024];
+        inputPacket[0] = new Integer(1).byteValue();
+        inputPacket[1] = new Integer(1).byteValue();
+        inputPacket[2] = ((Integer)r.nextInt(255)).byteValue();
+        inputPacket[3] = ((Integer)r.nextInt(255)).byteValue();
+        int packetNumber = (256 * Byte.toUnsignedInt(inputPacket[2])) + Byte.toUnsignedInt(inputPacket[3]);
+
+        r.nextBytes(bodyValue);
+        System.arraycopy(bodyValue, 0, inputPacket, 4, 1024);
+        
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(1028);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertEquals("Correct body is maintained", bodyValue, createdPacket.getBodyData());
+        assertEquals("Correct packet number is maintained", packetNumber, ((BodyPacket)createdPacket).getPacketNumber());
+        assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
+
+    }
+
+    @Test
+    public void smallerFinalPacketContainsCorrectBody(){
+        DatagramPacket dummyInput = new DatagramPacket(new byte[1028], 1028);
+        byte[] inputPacket = new byte[1028];
+        Random r = new Random();
+
+        int dataSize = r.nextInt(1023) + 1; //guaranteed to not be full size or empty
+
+        byte[] bodyValue = new byte[dataSize];
+        inputPacket[0] = new Integer(3).byteValue();
+        inputPacket[1] = new Integer(1).byteValue();
+        inputPacket[2] = ((Integer)r.nextInt(255)).byteValue();
+        inputPacket[3] = ((Integer)r.nextInt(255)).byteValue();
+        int packetNumber = (256 * Byte.toUnsignedInt(inputPacket[2])) + Byte.toUnsignedInt(inputPacket[3]);
+
+        r.nextBytes(bodyValue);
+        System.arraycopy(bodyValue, 0, inputPacket, 4, dataSize);
+        
+        dummyInput.setData(inputPacket);
+        dummyInput.setLength(dataSize + 4);
+
+        Packet createdPacket = PacketFactory.parsePacket(dummyInput);
+        assertEquals("Correct body is maintained", bodyValue, createdPacket.getBodyData());
+        assertEquals("Correct packet number is maintained", packetNumber, ((BodyPacket)createdPacket).getPacketNumber());
+        assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
+
+    }
+}
+

--- a/test/packet/PacketCreationTest.java
+++ b/test/packet/PacketCreationTest.java
@@ -146,7 +146,7 @@ public class PacketCreationTest {
         dummyInput.setLength(1028);
 
         Packet createdPacket = PacketFactory.parsePacket(dummyInput);
-        assertEquals("Correct body is maintained", bodyValue, createdPacket.getBodyData());
+        assertArrayEquals("Correct body is maintained", bodyValue, createdPacket.getBodyData());
         assertEquals("Correct packet number is maintained", packetNumber, ((BodyPacket)createdPacket).getPacketNumber());
         assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
 
@@ -174,10 +174,9 @@ public class PacketCreationTest {
         dummyInput.setLength(dataSize + 4);
 
         Packet createdPacket = PacketFactory.parsePacket(dummyInput);
-        assertEquals("Correct body is maintained", bodyValue, createdPacket.getBodyData());
+        assertArrayEquals("Correct body is maintained", bodyValue, createdPacket.getBodyData());
         assertEquals("Correct packet number is maintained", packetNumber, ((BodyPacket)createdPacket).getPacketNumber());
         assertTrue("The created packet should have file id 1", createdPacket.getFileId() == new Integer(1).byteValue());
-
     }
 }
 


### PR DESCRIPTION
The PacketFactory and FileBuilder factory classes allow multiple DatagramPackets to be combined into a form which is then suitable for writing to a file in a relatively simple way.